### PR TITLE
Upgrade to play-filters 3.3.0

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -35,9 +35,7 @@ object Dependencies {
   val compile = Seq(
     filters,
     "uk.gov.hmrc" %% "crypto" % "3.0.0",
-    "uk.gov.hmrc" %% "http-verbs" % "3.0.0",
-    "uk.gov.hmrc" %% "play-auditing" % "0.2.0",
-    "uk.gov.hmrc" %% "play-filters" % "3.2.0",
+    "uk.gov.hmrc" %% "play-filters" % "3.3.0",
     "uk.gov.hmrc" %% "play-graphite" % "2.0.0",
     "com.typesafe.play" %% "play" % PlayVersion.current,
     "com.kenshoo" %% "metrics-play" % "2.3.0_0.1.8"


### PR DESCRIPTION
Also remove dependency on http-verbs and play-auditing as
these are pulled in transitively via play-filters.

This does similar things to straighten out the dependency tree as https://github.com/hmrc/microservice-bootstrap/pull/6. The dep tree now looks like:

<img width="717" alt="screen shot 2015-11-17 at 17 10 35" src="https://cloud.githubusercontent.com/assets/4593903/11218662/25c08248-8d4e-11e5-8395-bf7f7f818c7b.png">
