### PR TITLE
Do not cache InternalServerError responses by default

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/frontend/bootstrap/ShowErrorPage.scala
+++ b/src/main/scala/uk/gov/hmrc/play/frontend/bootstrap/ShowErrorPage.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.play.frontend.bootstrap
 
 import play.api._
+import play.api.http.HeaderNames._
 import play.api.i18n.Messages
 import play.api.mvc.Results._
 import play.api.mvc.{Result, _}
@@ -56,7 +57,7 @@ trait ShowErrorPage extends GlobalSettings {
 
   def resolveError(rh: RequestHeader, ex: Throwable) = ex.getCause match {
     case ApplicationException(domain, result, _) => result
-    case _ => InternalServerError(internalServerErrorTemplate(rh))
+    case _ => InternalServerError(internalServerErrorTemplate(rh)).withHeaders(CACHE_CONTROL -> "no-cache")
   }
 
 }

--- a/src/test/scala/uk/gov/hmrc/play/frontend/bootstrap/ShowErrorPageSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/frontend/bootstrap/ShowErrorPageSpec.scala
@@ -37,7 +37,9 @@ class ShowErrorPageSpec extends WordSpecLike with Matchers {
     "return a generic InternalServerError result" in {
       val exception = new Exception("Runtime exception")
       val result = resolveError(FakeRequestHeader, exception)
+
       result.header.status shouldBe INTERNAL_SERVER_ERROR
+      result.header.headers should contain (CACHE_CONTROL -> "no-cache")
     }
 
     "return a generic InternalServerError result if the exception cause is null" in {
@@ -45,6 +47,7 @@ class ShowErrorPageSpec extends WordSpecLike with Matchers {
       val result = resolveError(FakeRequestHeader, exception)
 
       result.header.status shouldBe INTERNAL_SERVER_ERROR
+      result.header.headers should contain (CACHE_CONTROL -> "no-cache")
     }
 
     "return an InternalServerError result for an application error" in {


### PR DESCRIPTION
Added 'Cache-Control: no-cache' to the default HTTP 500 error response.
