### PR TITLE
Upgrade to latest play-filters version

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -35,7 +35,7 @@ object Dependencies {
   val compile = Seq(
     filters,
     "uk.gov.hmrc" %% "crypto" % "3.1.0",
-    "uk.gov.hmrc" %% "play-filters" % "4.6.0",
+    "uk.gov.hmrc" %% "play-filters" % "4.7.0",
     "uk.gov.hmrc" %% "play-graphite" % "2.0.0",
     "com.typesafe.play" %% "play" % PlayVersion.current,
     "com.kenshoo" %% "metrics-play" % "2.3.0_0.1.8"


### PR DESCRIPTION
After recent updates to http-verbs and play-auditing, downstream libraries need to update relevant dependency versions.
