### PR TITLE
TXMNT-366 Update play-filters and remove PlayException handling

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -35,7 +35,7 @@ object Dependencies {
   val compile = Seq(
     filters,
     "uk.gov.hmrc" %% "crypto" % "3.1.0",
-    "uk.gov.hmrc" %% "play-filters" % "5.3.0",
+    "uk.gov.hmrc" %% "play-filters" % "5.4.0",
     "uk.gov.hmrc" %% "play-graphite" % "3.0.0",
     "com.typesafe.play" %% "play" % PlayVersion.current,
     "de.threedimensions" %% "metrics-play" % "2.5.13",

--- a/src/main/scala/uk/gov/hmrc/play/frontend/bootstrap/ShowErrorPage.scala
+++ b/src/main/scala/uk/gov/hmrc/play/frontend/bootstrap/ShowErrorPage.scala
@@ -57,7 +57,7 @@ trait ShowErrorPage extends GlobalSettings {
   final override def onHandlerNotFound(rh: RequestHeader) =
     Future.successful(NotFound(notFoundTemplate(rh)))
 
-  def resolveError(rh: RequestHeader, ex: Throwable) = ex.getCause match {
+  def resolveError(rh: RequestHeader, ex: Throwable) = ex match {
     case ApplicationException(domain, result, _) => result
     case _ => InternalServerError(internalServerErrorTemplate(rh)).withHeaders(CACHE_CONTROL -> "no-cache")
   }

--- a/src/test/scala/uk/gov/hmrc/play/frontend/bootstrap/ShowErrorPageSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/frontend/bootstrap/ShowErrorPageSpec.scala
@@ -62,9 +62,8 @@ class ShowErrorPageSpec extends WordSpecLike with Matchers with OneAppPerSuite {
       )
 
       val appException = new ApplicationException("paye", theResult, "application exception")
-      val exception = new Exception(appException)
 
-      val result = resolveError(FakeRequestHeader, exception)
+      val result = resolveError(FakeRequestHeader, appException)
 
       result shouldBe theResult
     }


### PR DESCRIPTION
Play 2.5 no longer wraps service generated exceptions in a PlayException
so the ShowErrorPage class fails to match on ex.getCause as it is null.

Change the handler to match on the provided Throwable instead and update the
test cases.
