### PR TITLE
Fix deprecation warning in Play 2.5

### DIFF
--- a/src/main/resources/common.conf
+++ b/src/main/resources/common.conf
@@ -21,7 +21,7 @@ run.mode=Dev
 # If you deploy your application to several instances be sure to use the same key!
 
 # this key is for local development only!
-application.secret="yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
+play.crypto.secret="yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
 
 # this key is for local development only!
 cookie.encryption.key="gvBoGdgzqG1AarzF1LY0zQ=="


### PR DESCRIPTION
My front-end app spits out the following warning:

```
2016-11-02 13:11:09,899 level=[WARN] logger=[application] thread=[application-akka.actor.default-dispatcher-3] rid=[] user=[] message=[common.conf @ jar:file:/Users/rhu/dev/hmrc/api-documentation-raml-frontend/lib_managed/jars/uk.gov.hmrc/frontend-bootstrap_2.11/frontend-bootstrap_2.11-7.5.0.jar!/common.conf: 24: application.secret is deprecated, use play.crypto.secret instead] 
```