### PR TITLE
common.conf: change play.i18n.langs to array type

### DIFF
--- a/src/main/resources/common.conf
+++ b/src/main/resources/common.conf
@@ -46,7 +46,7 @@ play.http.session.cookieName="mdtp"
 
 # The application languages
 # ~~~~~
-play.i18n.langs="en"
+play.i18n.langs=["en"]
 
 # Logger
 # ~~~~~

--- a/src/test/scala/uk/gov/hmrc/play/frontend/bootstrap/CommonConfigLoadSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/frontend/bootstrap/CommonConfigLoadSpec.scala
@@ -1,0 +1,43 @@
+package uk.gov.hmrc.play.frontend.bootstrap
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{Matchers, WordSpecLike}
+import play.api._
+import play.api.http.HttpConfiguration
+import play.api.i18n.{Langs, MessagesApi}
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.inject.{ApplicationLifecycle, ConfigurationProvider}
+import play.api.libs.Files.TemporaryFileCreator
+import play.api.libs.crypto._
+import play.api.routing.Router
+
+import scala.concurrent.ExecutionContext
+
+class CommonConfigLoadSpec extends WordSpecLike with Matchers {
+  "config loading" should {
+    "load config correctly" in {
+      val app = new GuiceApplicationBuilder()
+        .configure(Configuration(ConfigFactory.load("common.conf")))
+        .build()
+      val injector = app.injector
+      injector.instanceOf[Langs].availables should not be('empty)
+      injector.instanceOf[MessagesApi] should not be(null)
+      injector.instanceOf[Environment] should not be(null)
+      injector.instanceOf[ConfigurationProvider] should not be(null)
+      injector.instanceOf[Configuration] should not be(null)
+      injector.instanceOf[HttpConfiguration] should not be(null)
+      injector.instanceOf[ApplicationLifecycle] should not be(null)
+      injector.instanceOf[Router] should not be(null)
+      injector.instanceOf[ActorSystem] should not be(null)
+      injector.instanceOf[Materializer] should not be(null)
+      injector.instanceOf[ExecutionContext] should not be(null)
+      injector.instanceOf[CryptoConfig] should not be(null)
+      injector.instanceOf[CookieSigner] should not be(null)
+      injector.instanceOf[CSRFTokenSigner] should not be(null)
+      injector.instanceOf[play.api.libs.Crypto] should not be(null)
+      injector.instanceOf[TemporaryFileCreator] should not be(null)
+    }
+  }
+}


### PR DESCRIPTION
This fixes a bug introduced in #48 which won't allow Messages or Languages to be loaded given the current config