### PR TITLE
DC-890: Added support for DI and allow to override configuration

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -35,7 +35,7 @@ object Dependencies {
 
   val compile = Seq(
     filters,
-    "uk.gov.hmrc" %% "crypto" % "4.2.0",
+    "uk.gov.hmrc" %% "crypto" % "4.4.0",
     "uk.gov.hmrc" %% "play-filters" % "5.15.0",
     "uk.gov.hmrc" %% "play-graphite" % "3.2.0",
     "com.typesafe.play" %% "play" % PlayVersion.current,

--- a/src/main/scala/uk/gov/hmrc/play/frontend/bootstrap/FrontendGlobal.scala
+++ b/src/main/scala/uk/gov/hmrc/play/frontend/bootstrap/FrontendGlobal.scala
@@ -77,7 +77,7 @@ abstract class DefaultFrontendGlobal
   with ShowErrorPage
   with MicroserviceFilterSupport {
 
-  private lazy val configuration = Play.current.configuration
+  def configuration = Play.current.configuration
 
   lazy val appName: String = configuration.getString("appName").getOrElse("APP NAME NOT SET")
   lazy val enableSecurityHeaderFilter: Boolean = configuration.getBoolean("security.headers.filter.enabled").getOrElse(true)


### PR DESCRIPTION
Two changes are proposed with this PR:
1) A new version of crypto library is available, and it supports DI (along with the old behaviour)
2) The configuration definition as a `private lazy val` doesn't allow us to override it with an injected configuration (`Play.current.configuration` is deprecated, and new apps that use DI need to be able to inject it somehow), hence the proposal to make it a def (it cannot be `private`, and it cannot be a `lazy val` as it can't be overridden)

Thanks!