### PR TITLE
Bump Play-ui version to strip query strings from Google Analytics

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -46,7 +46,7 @@ object Dependencies {
     "uk.gov.hmrc" %% "govuk-template" % "5.3.0",
     "uk.gov.hmrc" %% "play-config" % "4.3.0",
     "uk.gov.hmrc" %% "play-health" % "2.1.0",
-    "uk.gov.hmrc" %% "play-ui" % "7.8.0",
+    "uk.gov.hmrc" %% "play-ui" % "7.10.0",
     "com.typesafe.play" %% "play" % PlayVersion.current,
     "de.threedimensions" %% "metrics-play" % "2.5.13"
   )


### PR DESCRIPTION
Bump the version of Play-UI to 7.10.0 which includes code to prevent PII in query strings from inadvertently being sent to Google Analytics.