### PR TITLE
Bump play-ui version

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -45,7 +45,7 @@ object Dependencies {
     "uk.gov.hmrc"        %% "govuk-template"           % "5.3.0",
     "uk.gov.hmrc"        %% "play-config"              % "4.3.0",
     "uk.gov.hmrc"        %% "play-health"              % "2.1.0",
-    "uk.gov.hmrc"        %% "play-ui"                  % "7.14.0",
+    "uk.gov.hmrc"        %% "play-ui"                  % "7.15.0",
     "com.typesafe.play"  %% "play"                     % PlayVersion.current,
     "de.threedimensions" %% "metrics-play"             % "2.5.13"
   )


### PR DESCRIPTION
Bump Play-UI version to include the latest release 7.15.0 which has some small text changes to the beta banner