### PR TITLE
Bump play-ui to 7.16.0 to include Welsh HMRC Logo text from DL-866

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -45,7 +45,7 @@ object Dependencies {
     "uk.gov.hmrc"        %% "govuk-template"           % "5.3.0",
     "uk.gov.hmrc"        %% "play-config"              % "4.3.0",
     "uk.gov.hmrc"        %% "play-health"              % "2.1.0",
-    "uk.gov.hmrc"        %% "play-ui"                  % "7.15.0",
+    "uk.gov.hmrc"        %% "play-ui"                  % "7.16.0",
     "com.typesafe.play"  %% "play"                     % PlayVersion.current,
     "de.threedimensions" %% "metrics-play"             % "2.5.13"
   )


### PR DESCRIPTION
We have merged a PR from the Telford Live services team into play-ui with new text, etc. relating to Welsh features for the HMRC Logo, this PR updates frontend-bootstrap to include this update.