### PR TITLE
Bump play-ui version to 7.20.0 for fix to error styling

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -45,7 +45,7 @@ object Dependencies {
     "uk.gov.hmrc"        %% "govuk-template"           % "5.3.0",
     "uk.gov.hmrc"        %% "play-config"              % "4.3.0",
     "uk.gov.hmrc"        %% "play-health"              % "2.1.0",
-    "uk.gov.hmrc"        %% "play-ui"                  % "7.19.0",
+    "uk.gov.hmrc"        %% "play-ui"                  % "7.20.0",
     "com.typesafe.play"  %% "play"                     % PlayVersion.current,
     "de.threedimensions" %% "metrics-play"             % "2.5.13"
   )


### PR DESCRIPTION
Bump play-ui version to 7.20.0 for the following change https://github.com/hmrc/play-ui/pull/101

Which contains a fix for missing styling on error messages, details in the play-ui pull request.