### PR TITLE
[TR] TXM-3192 simplify explicit auditing

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -35,9 +35,9 @@ object Dependencies {
   val compile = Seq(
     filters,
     "uk.gov.hmrc"        %% "crypto"                   % "4.4.0",
-    "uk.gov.hmrc"        %% "play-auditing"            % "3.7.0",
+    "uk.gov.hmrc"        %% "play-auditing"            % "3.9.0-play-25",
     "uk.gov.hmrc"        %% "http-verbs"               % "7.3.0",
-    "uk.gov.hmrc"        %% "http-verbs-play-25"       % "0.11.0",
+    "uk.gov.hmrc"        %% "http-verbs-play-25"       % "0.12.0",
     "uk.gov.hmrc"        %% "play-graphite"            % "3.6.2",
     "uk.gov.hmrc"        %% "play-authorised-frontend" % "7.0.0",
     "ch.qos.logback"     % "logback-core"              % "1.1.7",

--- a/src/main/scala/uk/gov/hmrc/play/frontend/config/HttpAuditEvent.scala
+++ b/src/main/scala/uk/gov/hmrc/play/frontend/config/HttpAuditEvent.scala
@@ -49,7 +49,11 @@ trait HttpAuditEvent {
     import headers._
     import uk.gov.hmrc.play.audit.http.HeaderFieldsExtractor._
 
-    val requiredFields = hc.toAuditDetails(
+    val requiredFields = Map(
+      "ipAddress"            -> hc.forwarded.map(_.value).getOrElse("-"),
+      hc.names.authorisation -> hc.authorization.map(_.value).getOrElse("-"),
+      hc.names.token         -> hc.token.map(_.value).getOrElse("-"),
+      hc.names.deviceID      -> hc.deviceID.getOrElse("-"),
       Input           -> s"Request to ${request.path}",
       Method          -> request.method.toUpperCase,
       UserAgentString -> request.headers.get(UserAgent).getOrElse("-"),

--- a/src/main/scala/uk/gov/hmrc/play/frontend/config/LoadAuditingConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/play/frontend/config/LoadAuditingConfig.scala
@@ -45,10 +45,11 @@ object LoadAuditingConfig {
                   .getOrElse(throw new Exception("Missing consumer baseUri for auditing"))
               )
             }
-            .getOrElse(throw new Exception("Missing consumer configuration for auditing")))
+            .getOrElse(throw new Exception("Missing consumer configuration for auditing"))),
+          auditSource = Play.configuration.getString("appName").getOrElse(throw new Exception("Missing app name needed for auditSource"))
         )
       } else {
-        AuditingConfig(consumer = None, enabled = false)
+        AuditingConfig(consumer = None, enabled = false, auditSource = "auditing disabled")
       }
 
     }

--- a/src/main/scala/uk/gov/hmrc/play/frontend/controller/FrontendController.scala
+++ b/src/main/scala/uk/gov/hmrc/play/frontend/controller/FrontendController.scala
@@ -28,7 +28,7 @@ import scala.concurrent._
 trait FrontendController extends Controller with Utf8MimeTypes {
 
   implicit def hc(implicit request: Request[_]): HeaderCarrier =
-    HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
+    HeaderCarrierConverter.fromHeadersAndSessionAndRequest(request.headers, Some(request.session), Some(request))
 
   implicit def mdcExecutionContext(implicit loggingDetails: LoggingDetails): ExecutionContext =
     MdcLoggingExecutionContext.fromLoggingDetails

--- a/src/test/scala/uk/gov/hmrc/play/frontend/controller/FrontendControllerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/frontend/controller/FrontendControllerSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.frontend.controller
+
+import org.scalatest.{Matchers, WordSpecLike}
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Headers
+import play.api.test.FakeRequest
+import uk.gov.hmrc.play.audit.AuditExtensions
+
+
+class FrontendControllerSpec extends WordSpecLike with Matchers {
+
+  val frontendController = new FrontendController {}
+
+  "FrontendController" should {
+    "add path to header carrier for tags" in {
+      //this test ensures that the combination of http-verbs-play-25 and play-auditing adds
+      //the request path as a tag for classes that extend FrontendController
+      val request = new FakeRequest[JsValue]("GET", "/the/request/path", Headers(), Json.obj())
+      val headerCarrier = frontendController.hc(request)
+      val tags = new AuditExtensions.AuditHeaderCarrier(headerCarrier).toAuditTags()
+      tags.get("path") shouldBe Some("/the/request/path")
+    }
+  }
+}


### PR DESCRIPTION
This commit updates frontend-bootstrap to the version of play-auditing
with new methods for explicit auditing.

The intention is that the new methods make it easier to create an
explicit audit event with the correct tags.

In order to simplify providing the request path in the explicit audit
the request path is added to HeaderCarrier by http-verbs-play-25.

This project just needs to pass the request into the method
HeaderCarrierConverter.fromHeadersAndSessionAndRequest so that
the path is added.

The play-auditing changes also included removing default values from
the detail for explicit audits. However, implicit audits should remain
unchanged so the fields removed from detail are re-added here.