### PR TITLE
[TR] TXM-3316 upgrade play-auditing for user-agent fix

### DIFF
--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -8,7 +8,7 @@ object LibDependencies {
   val compile = Seq(
     filters,
     "uk.gov.hmrc"                    %% "crypto"                   % "4.4.0",
-    "uk.gov.hmrc"                    %% "play-auditing"            % "3.9.0-play-25",
+    "uk.gov.hmrc"                    %% "play-auditing"            % "3.12.0-play-25",
     "uk.gov.hmrc"                    %% "http-verbs"               % "7.3.0",
     "uk.gov.hmrc"                    %% "http-verbs-play-25"       % "0.12.0",
     "uk.gov.hmrc"                    %% "play-graphite"            % "3.6.2",


### PR DESCRIPTION
Ugrades the play auditing library to include the fix which
sets the User-Agent header when writing audit data to datastream